### PR TITLE
[C] fix game start race condition

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.7.4-alpha",
+  "version": "0.7.5-alpha",
   "name": "space-surveyors",
   "author": "Rubin EPO",
   "module": "dist/space-surveyors.esm.js",

--- a/src/shapes/event.ts
+++ b/src/shapes/event.ts
@@ -1,6 +1,7 @@
 type GameEventName =
   | 'started'
   | 'resize'
+  | 'gameStart'
   | 'timeStart'
   | 'timeEnd'
   | 'targetSet'

--- a/src/space-surveyors.jsx
+++ b/src/space-surveyors.jsx
@@ -17,7 +17,6 @@ import { getAspectRatio } from './utils';
 const SpaceSurveyors = () => {
   const initialState = {
     menu: 'landing',
-    running: false,
     score: Score(),
     boundingRect: null,
     aspectRatio: null,
@@ -62,7 +61,7 @@ const SpaceSurveyors = () => {
     switch (action) {
       case 'start':
         setState({ ...state, menu: null });
-        engine.current.start();
+        engine.current.dispatch({ type: 'gameStart' });
         break;
       case 'restart':
         window.location.reload(false);
@@ -94,7 +93,7 @@ const SpaceSurveyors = () => {
     }
   };
 
-  const { menu, running, score, boundingRect, aspectRatio } = state;
+  const { menu, score, boundingRect, aspectRatio } = state;
   const GameMenu = GameMenus[menu];
 
   return (
@@ -116,7 +115,6 @@ const SpaceSurveyors = () => {
               ref={engine}
               entities={Entities(boundingRect, aspectRatio)}
               systems={Systems}
-              running={running}
               onEvent={handleEvent}
             ></GameEngine>
           )}

--- a/src/systems/timer.ts
+++ b/src/systems/timer.ts
@@ -4,7 +4,6 @@ import { FINISH_SCREEN_TIME, GAME_TIME, WARMUP_TIME } from '@constants/index';
 const timeline: GameSystem = (entities, { time, input, dispatch }) => {
   const { timer, state } = entities;
   const { current } = time;
-  const { timeRemaining } = timer;
   const { endTime, gameStart, startTime, stage } = state;
 
   switch (stage) {
@@ -17,19 +16,16 @@ const timeline: GameSystem = (entities, { time, input, dispatch }) => {
 
     /** track time remaining in gameplay, then end gameplay */
     case 'running':
-      if (timeRemaining > 0) {
-        const newTimeRemaining = Math.max(0, GAME_TIME - (current - startTime));
+      const timeRemaining = Math.max(0, GAME_TIME - (current - startTime));
 
-        if (newTimeRemaining === 0) {
-          dispatch({ type: 'timeEnd' });
-        }
-
-        return {
-          ...entities,
-          timer: { ...timer, timeRemaining: newTimeRemaining },
-        };
+      if (timeRemaining === 0) {
+        dispatch({ type: 'timeEnd' });
       }
-      break;
+
+      return {
+        ...entities,
+        timer: { ...timer, timeRemaining },
+      };
     /** if an end time has passed, wait alloted time to display the finished screen then quit,
      *  if user clicks, quit
      */
@@ -46,13 +42,11 @@ const timeline: GameSystem = (entities, { time, input, dispatch }) => {
 
 /** log the initial start time and enter the warmup state */
 const onGameStart: GameSystem = (entities, { events, time }) => {
-  const event = events.find((e) => e.type === 'started');
+  const event = events.find((e) => e.type === 'gameStart');
 
   if (event) {
     const { state } = entities;
     const { current } = time;
-
-    console.log(current);
 
     return {
       ...entities,
@@ -83,6 +77,7 @@ const onTimeEnd: GameSystem = (entities, { events, time }) => {
   const event = events.find((e) => e.type === 'timeEnd');
 
   if (event) {
+    console.log('found time end');
     const { current } = time;
     const { backdrop, state, skyObjects, camera } = entities;
     const showEndgame = true;

--- a/src/systems/timer.ts
+++ b/src/systems/timer.ts
@@ -77,7 +77,6 @@ const onTimeEnd: GameSystem = (entities, { events, time }) => {
   const event = events.find((e) => e.type === 'timeEnd');
 
   if (event) {
-    console.log('found time end');
     const { current } = time;
     const { backdrop, state, skyObjects, camera } = entities;
     const showEndgame = true;


### PR DESCRIPTION
Fix the race condition where the game does not start/stop consistently in Safari. It looks like what was happening was that the `running` parameter being updated by `setState` was causing a race condition where sometimes the engine would restart with fresh entities. I think this could possibly relate to #14 where it was not possible to swap gameplay states because entities would always set back to start. Using `engine.swap()` should be investigated again but in an always-running context.